### PR TITLE
Remove 'token' from HIGH_SECRET_HINTS.

### DIFF
--- a/bandit_plugins/high_entropy_string.py
+++ b/bandit_plugins/high_entropy_string.py
@@ -121,7 +121,6 @@ HIGH_SECRET_HINTS = [
     re.compile(r'pass', re.IGNORECASE),
     re.compile(r'passwd', re.IGNORECASE),
     re.compile(r'password', re.IGNORECASE),
-    re.compile(r'token', re.IGNORECASE),
     re.compile(r'login', re.IGNORECASE)
 ]
 SAFE_VAR_HINTS = [


### PR DESCRIPTION
'token' matches both this pattern and the 'tok' pattern above in LOW_SECRET_HINTS. This means it gets an instant 'High' classification even if the string contains nothing else.

Removing 'token' from HIGH_SECRET_HINTS means that 'token' alone will get a 'Low' classification. Ideally the secret match should know how to deal with duplicate patterns.
