### PR TITLE
Return unicode string bandit.Issue from HES check

### DIFF
--- a/bandit_plugins/high_entropy_string.py
+++ b/bandit_plugins/high_entropy_string.py
@@ -625,5 +625,5 @@ def _report(strings):
         return bandit.Issue(
             severity=severity,
             confidence=confidence,
-            text='Possible hardcoded secret(s) {0}.'.format(', '.join(reports))
+            text=u'Possible hardcoded secret(s) {0}.'.format(', '.join(reports))
         )


### PR DESCRIPTION
The official bandit hardcoded password plugin will return a unicode string if the hardcoded password is unicode, so let's do the same here.

For reference:
https://github.com/openstack/bandit/blob/master/bandit/plugins/general_hardcoded_password.py#L32

"If format is a Unicode object, or if any of the objects being converted using the %s conversion are Unicode objects, the result will also be a Unicode object." [https://docs.python.org/2/library/stdtypes.html#string-formatting]